### PR TITLE
fix(build): remove prepublish test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "lint:check": "eslint",
     "format:check": "prettier . --check",
     "format:write": "prettier . --write",
-    "test": "node bin/test.js",
-    "prepublishOnly": "npm run build && npm run test"
+    "test": "node bin/test.js"
   },
   "files": [
     "dist/**/*"


### PR DESCRIPTION
Publish is only via GitHub Actions now anyway, there's no need for this check. It was blocking the publish since the test step improved in #552