### PR TITLE
chore!: test on node 24 (new lts), drop node 18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: "yarn"
       - name: run eslint
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
       - run: yarn install --immutable

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,7 +16,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: "yarn"
       - run: yarn install --immutable
       - run: yarn sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: "yarn"
       - name: Install deps and build
         run: |
@@ -17,7 +17,7 @@ jobs:
           yarn build
           rm -rf node_modules
 
-      - name: test built package on node@22
+      - name: test built package on node@24
         working-directory: ./package-test/
         run: |
           # CI implies --immutable
@@ -32,8 +32,8 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
-      - name: test build package on node@20
+          node-version: 22
+      - name: test build package on node@22
         working-directory: ./package-test/
         run: |
           node -v


### PR DESCRIPTION
Node 24 is LTS on 2025-10-28 https://github.com/nodejs/Release
Node 18 is EOL since 2025-04-30
